### PR TITLE
add-overwatts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Our own country-by-country research into the size of the world's transmission gr
 <!-- COLLAPSE:info title="Global Data Catalogs" -->
 ### Global Data Catalogs 
 * [Open Infrastructure Map](https://openinframap.org/) [[Code](https://github.com/openinframap/openinframap)] (map)
+* [OverWatts](https://www.overwatts.com/) (map)
 * [GridFinder](https://gridfinder.rdrn.me/) [[Code](https://github.com/carderne/gridfinder)] (map)
 * [FLOSM Power Grid](https://www.flosm.org/en/powergrid.html) (odbl) (map)
 * [Electricity Maps - Electricity Grid Carbon Emissions](https://app.electricitymaps.com/) [[Code](https://github.com/electricitymaps/electricitymaps-contrib)] (map) 
@@ -65,6 +66,7 @@ Our own country-by-country research into the size of the world's transmission gr
 * [DOE Global Energy Storage Database](https://gesdb.sandia.gov/projects.html) (dataset)
 * [GloHydroRes](https://zenodo.org/records/14526360) - A global dataset combining open-source hydropower plant and reservoir data.
 * [Global Dam Watch](https://www.globaldamwatch.org/)
+
 
 <!-- END COLLAPSE -->
 


### PR DESCRIPTION
Added overwatts.com line 50

OverWatts — a free tactical map of world energy infrastructure and live tanker traffic: refineries, LNG terminals, pipelines, power plants, mines, maritime chokepoints, and moving AIS vessels, plus grid, storage and interconnector layers, on a dark command-terminal basemap.

- Live: https://www.overwatts.com/
- Data draws on OSM, Global Energy Monitor, ENTSO-E, GDELT and live AIS,
  alongside a country × asset-class atlas (/country/[iso]/[kind]) generated
  from the same corpus this list already curates.

Follows the list's contribution format: * (Title)(link)(license)(tags).
Placed in Global Data Catalogs next to Open Infrastructure Map as the closest comparator in scope (global, OSM-grounded, live interactive map rather than a static dataset).